### PR TITLE
Check for definedness of $self->content

### DIFF
--- a/lib/HTTP/Message.pm
+++ b/lib/HTTP/Message.pm
@@ -513,7 +513,7 @@ sub as_string
 
     # The calculation of content might update the headers
     # so we need to do that first.
-    my $content = $self->content;
+    my $content = defined $self->content ? $self->content : '';
 
     return join("", $self->{'_headers'}->as_string($eol),
 		    $eol,


### PR DESCRIPTION
Fix uninitialized value warning at line 516 of Message.pm

This warning is thrown, for example, whenever you do:

$response->request->as_string

since there is no content in the request.
